### PR TITLE
Fix a minor typo and correct the type for vread() to make it work

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ curl 'http://localhost:8080/DiagnosticOrder/example' \
 ```
 
 ## Getting more sample data
-You can load sample data from SMART's [Sample Patietns](https://github.com/chb/smart_sample_patients/tree/fhir):
+You can load sample data from SMART's [Sample Patients](https://github.com/chb/smart_sample_patients/tree/fhir):
 
 ```
 $ sudo apt-get install python-jinja2

--- a/grails-app/controllers/fhir/ApiController.groovy
+++ b/grails-app/controllers/fhir/ApiController.groovy
@@ -153,7 +153,7 @@ class ApiController {
   }
 
   def vread() {
-    Map h = sqlService.getFhirVersion(params.resource, params.id, Long.parseLong(params.vid))
+    ResourceVersion h = sqlService.getFhirVersion(params.resource, params.id, Long.parseLong(params.vid))
     readService(h)
   }
 


### PR DESCRIPTION
Currently attempting to do a vread() returns a type cast error, as instead of using ResourceVersion it uses Map. This corrects that, along with fixing the spelling of "Sample Patients" in the README.md.
