### PR TITLE
Add Dockerfile and docker-compose.yml to allow easier deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM tomcat:8.0
+
+COPY target/*.war /usr/local/tomcat/webapps/
+
+
+# If you supply a tomcat-users.xml you can uncomment this line
+# it will move it to the appropriate location.
+#COPY tomcat-users.xml conf/tomcat-users.xml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+web:
+  build: .
+  ports:
+    - "8080:8080"
+  environment:
+    DB: jdbc:postgresql://db/fhir
+    PGPASSWORD: fhir
+    AUTH: false
+  links:
+    - db:db
+db:
+  image: postgres
+  environment:
+    POSTGRES_PASSWORD: fhir
+    POSTGRES_USER: fhir

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -6,26 +6,26 @@ dataSource {
 	pooled = true
     driverClassName = "org.postgresql.Driver"
     dialect = "net.kaleidos.hibernate.PostgresqlExtensionsDialect"
-    url = "jdbc:postgresql://localhost/fhir"
-    username = "fhir"
-    password = "fhir"
+    url = System.env.DB ?: "jdbc:postgresql://localhost/fhir"
+    username = System.env.PGUSER ?:"fhir"
+    password = System.env.PGPASSWORD ?:"fhir"
     dbCreate = "update"
-	
+
 	properties {
 		maxActive = 50
 		maxIdle = 25
 		minIdle = 1
 		initialSize = 1
-   
+
 		numTestsPerEvictionRun = 3
 		maxWait = 10000
-   
+
 		testOnBorrow = true
 		testWhileIdle = true
 		testOnReturn = true
-   
+
 		validationQuery = "select 1"
-   
+
 		minEvictableIdleTimeMillis = 1000 * 60 * 5
 		timeBetweenEvictionRunsMillis = 1000 * 60 * 5
 	 }
@@ -34,7 +34,7 @@ dataSource {
 
 hibernate { }
 
-environments { 
-   development { 
-   } 
-} 
+environments {
+   development {
+   }
+}


### PR DESCRIPTION
This change will make it possible for users familiar with docker to deploy an instance of this server. This handles setting up the postgres and tomcat server for the user. They will, however, still require grails installed on their system to build a war file.

Assuming docker and docker-compose are installed, standing up a server would require:

```
cd api-server
echo "war" | ./grailsw
docker-compose build
docker-compose up
```