### PR TITLE
Moved to Saxon-HE/9.5.1-5

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -29,7 +29,7 @@ grails.project.dependency.resolution = {
         runtime "joda-time:joda-time:2.2"
         runtime 'org.apache.commons:commons-io:1.3.2'
         runtime "org.mongodb:mongo-java-driver:2.11.3"
-        runtime 'net.sf.saxon:Saxon-HE:9.4'
+        runtime 'net.sf.saxon:Saxon-HE:9.5.1-5'
         runtime('org.codehaus.groovy.modules.http-builder:http-builder:0.5.2') {
             excludes 'groovy'
             excludes 'xml-apis'


### PR DESCRIPTION
http://mvnrepository.com/artifact/net.sf.saxon/Saxon-HE/9.5.1-5

Josh writes…

>The error message you've shown indicates a problem with Saxon-HE-9.4,
which is confirmed by this forum discussion. In theory this was fixed
in version 9.5.1.5.

>Are you willing to experiment a bit more? If so, please try updating
the saxon dependency to "9.5.1-5".

>Thanks Alan, for the report!  Great to hear this fixes the issue. One
more step: the "proper" way to implement this change to remove your
locally download .jar, edit the buildConfig to update the dependency
version (see the file I linked to in my last note), and then re-build.
If that works, we'll update our repo + docs! (And, if you want, you can
send a pull request with this change to us via GitHub;